### PR TITLE
Add TI-84 Plus CE Emulator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ Is your project mentioned in this list? See [mentioned.md](https://github.com/xx
 - [Clcalc.net](https://clcalc.net/) - Open-Source command-line style arbitrary precision calculator with mathematical, scientific, programming functions and more.
 - [Desmos](https://www.desmos.com/) - Online set of tools related to math, including a set of calculators, exams and more.
 - [Geogebra](https://www.geogebra.org/) - Free online math tools for graphing, geometry, 3D, and more. Includes interactive graphical calculator.
+- [TI-84 Plus CE Emulator](https://ti84ce.com/) - Full-featured TI-84 Plus CE running entirely in WebAssembly for free, no download required.
 
 ## Resources
 


### PR DESCRIPTION
Add TI-84 Plus CE Emulator to the Web section.
This is a fully functional TI-84 Plus CE calculator emulator that runs entirely in WebAssembly with PWA support. It provides identical functionality to the physical calculator at zero cost.