### PR TITLE
Add finance & insurance web calculators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,10 @@ Is your project mentioned in this list? See [mentioned.md](https://github.com/xx
 - [Clcalc.net](https://clcalc.net/) - Open-Source command-line style arbitrary precision calculator with mathematical, scientific, programming functions and more.
 - [Desmos](https://www.desmos.com/) - Online set of tools related to math, including a set of calculators, exams and more.
 - [Geogebra](https://www.geogebra.org/) - Free online math tools for graphing, geometry, 3D, and more. Includes interactive graphical calculator.
+- [MortgageCalcTools](https://mortgagecalctools.com/) - Free mortgage calculators for the US market: monthly payments, amortization, refinance break-even, affordability, PMI, FHA, VA, and more. 220+ pages of state-specific data.
+- [InsuranceCalcTools](https://insurancecalctools.com/) - Free insurance calculators covering life, auto, health, home, and disability. Compare premiums and estimate coverage needs with US-market data.
+- [CreditScoreCalcTools](https://creditscorecalctools.com/) - Credit score calculators and guides: FICO factor breakdown, debt payoff, balance transfer savings, and credit improvement timelines.
+- [EasyCalculators](https://easycalculators.com/) - 500+ free online calculators covering percentage, BMI, mortgage, GPA, tip, compound interest, and more. No signup required.
 
 ## Resources
 
@@ -101,5 +105,3 @@ Is your project mentioned in this list? See [mentioned.md](https://github.com/xx
 [![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Antoni Kepinski](https://akepinski.me) has waived all copyright and related or neighboring rights to this work.
-
-


### PR DESCRIPTION
Adds 4 free web calculator sites to the Web section:

- **[MortgageCalcTools](https://mortgagecalctools.com/)** — US mortgage calculators (monthly payments, amortization, refinance, PMI, FHA/VA, 220+ state-specific pages)
- **[InsuranceCalcTools](https://insurancecalctools.com/)** — Life, auto, health and home insurance calculators with NAIC/AM Best data
- **[CreditScoreCalcTools](https://creditscorecalctools.com/)** — FICO breakdown, debt payoff, balance transfer savings calculators
- **[EasyCalculators](https://easycalculators.com/)** — 500+ general-purpose calculators (percentage, BMI, mortgage, GPA, tip, compound interest)

All are free, no signup required, and focused on the US market.