### PR TITLE
Add FreeToolHub — 190+ free client-side browser tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ Is your project mentioned in this list? See [mentioned.md](https://github.com/xx
 - [Clcalc.net](https://clcalc.net/) - Open-Source command-line style arbitrary precision calculator with mathematical, scientific, programming functions and more.
 - [Desmos](https://www.desmos.com/) - Online set of tools related to math, including a set of calculators, exams and more.
 - [Geogebra](https://www.geogebra.org/) - Free online math tools for graphing, geometry, 3D, and more. Includes interactive graphical calculator.
+- [FreeToolHub](https://freetoolhub.org/) - Collection of 190+ free online calculators and file utilities that run entirely client-side, with no signup and no uploads.
 
 ## Resources
 


### PR DESCRIPTION
Adds [FreeToolHub](https://freetoolhub.org) to the **Web** section, next to Calculator.net.

It is a collection of 190+ free browser-based calculators (tax, finance, health, business) — all run client-side with no uploads.